### PR TITLE
ADd missing blank after STOP

### DIFF
--- a/FreeON/Optimizer.F90
+++ b/FreeON/Optimizer.F90
@@ -3055,7 +3055,7 @@ CONTAINS
     SELECT CASE(FromTo)
     CASE('CToWC');IFromTo=0
     CASE('WCToC');IFromTo=1
-    CASE DEFAULT; STOP'Err:WghtMtrx'
+    CASE DEFAULT; STOP 'Err:WghtMtrx'
     END SELECT
     DO AtB=1,NAtoms
        IF(IFromTo.EQ.0) THEN


### PR DESCRIPTION
The STOP statement requires preceding blank. Newer gcc
will fail with

     CASE DEFAULT; STOP'Err:WghtMtrx'
                      1
Error: Blank required in STOP statement near (1)

See:
https://bugs.gentoo.org/show_bug.cgi?id=604138

Signed-off-by: Justin Lecher <jlec@gentoo.org>